### PR TITLE
Clean up some compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,13 @@ else()
     set(SDL2_BUILDING_LIBRARY 1)
     find_package(SDL2 REQUIRED)
     find_package(SDL2_image REQUIRED)
-    include_directories(${SDL2_INCLUDE_DIRS})
-    include_directories(${SDL2IMAGE_INCLUDE_DIR})
+    include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
+    include_directories(SYSTEM ${SDL2IMAGE_INCLUDE_DIR})
     add_definitions(-DOPTION_ETHERNET=1)
 endif()
 
 if (UNIX)
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fpermissive")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fpermissive -pedantic -Wall")
 endif (UNIX)
 
 add_definitions(-DDEBUG)
@@ -74,12 +74,13 @@ include_directories(
     src/eez/libs/mqtt
     src/eez/platform/simulator
     src/eez/scpi
+)
 
+include_directories(SYSTEM
     src/third_party/libscpi/inc
     src/third_party/micropython
     src/third_party/micropython/ports/bb3
 )
-
 if(WIN32)
     include_directories(src/third_party/micropython/ports/bb3/win32)
 endif()

--- a/src/eez/gui/gui.cpp
+++ b/src/eez/gui/gui.cpp
@@ -72,7 +72,7 @@ void startThread() {
     mcu::display::onThemeChanged();
     touch::init();
     mouse::init();
-    g_guiMessageQueueId = osMessageCreate(osMessageQ(g_guiMessageQueue), NULL);
+    g_guiMessageQueueId = osMessageCreate(osMessageQ(g_guiMessageQueue), 0);
     g_guiTaskHandle = osThreadCreate(osThread(g_guiTask), nullptr);
 }
 

--- a/src/eez/libs/sd_fat/sd_fat.h
+++ b/src/eez/libs/sd_fat/sd_fat.h
@@ -147,9 +147,9 @@ class File {
     void print(char value);
 
   private:
-    bool m_isOpen;
+    bool m_isOpen{false};
 #ifdef EEZ_PLATFORM_SIMULATOR
-    FILE *m_fp;
+    FILE *m_fp{NULL};
 #else
     FIL m_file;
 #endif

--- a/src/eez/libs/sd_fat/simulator/sd_fat.cpp
+++ b/src/eez/libs/sd_fat/simulator/sd_fat.cpp
@@ -282,8 +282,7 @@ SdFatResult Directory::findNext(FileInfo &fileInfo) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-File::File() : m_fp(NULL), m_isOpen(false) {
-}
+File::File() {}
 
 bool File::open(const char *path, uint8_t mode) {
     const char *fmode;

--- a/src/eez/modules/dib-smx46/dib-smx46.cpp
+++ b/src/eez/modules/dib-smx46/dib-smx46.cpp
@@ -1031,7 +1031,7 @@ static char *g_labelPointer;
 void onSetLabel(char *value) {
     strcpy(g_labelPointer, value);
     popPage();
-};
+}
 
 void action_dib_smx46_edit_x_label() {
     int cursor = getFoundWidgetAtDown().cursor;

--- a/src/eez/modules/mcu/ethernet.cpp
+++ b/src/eez/modules/mcu/ethernet.cpp
@@ -93,7 +93,7 @@ osThreadDef(g_ethernetTask, mainLoop, osPriorityNormal, 0, 1024);
 #endif
 
 osMessageQDef(g_ethernetMessageQueue, 20, uint32_t);
-osMessageQId(g_ethernetMessageQueueId);
+osMessageQId g_ethernetMessageQueueId;
 
 static osThreadId g_ethernetTaskHandle;
 

--- a/src/eez/modules/mcu/ethernet.cpp
+++ b/src/eez/modules/mcu/ethernet.cpp
@@ -98,7 +98,7 @@ osMessageQId(g_ethernetMessageQueueId);
 static osThreadId g_ethernetTaskHandle;
 
 void initMessageQueue() {
-    g_ethernetMessageQueueId = osMessageCreate(osMessageQ(g_ethernetMessageQueue), NULL);
+    g_ethernetMessageQueueId = osMessageCreate(osMessageQ(g_ethernetMessageQueue), 0);
 }
 
 void startThread() {

--- a/src/eez/modules/mcu/simulator/display.cpp
+++ b/src/eez/modules/mcu/simulator/display.cpp
@@ -62,7 +62,6 @@ static uint32_t *g_buffer;
 static uint32_t *g_lastBuffer;
 
 static bool g_takeScreenshot;
-static int g_screenshotY;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -533,7 +532,6 @@ void drawVLine(int x, int y, int l) {
 
 void bitBlt(int x1, int y1, int x2, int y2, int dstx, int dsty) {
     int width = x2 - x1 + 1;
-    int height = y2 - y1 + 1;
 
     uint32_t *src = g_buffer + y1 * DISPLAY_WIDTH + x1;
     uint32_t *dst = g_buffer + dsty * DISPLAY_WIDTH + dstx;

--- a/src/eez/modules/psu/datetime.cpp
+++ b/src/eez/modules/psu/datetime.cpp
@@ -532,4 +532,4 @@ bool DateTime::operator!=(const DateTime &rhs) {
 
 } // namespace datetime
 } // namespace psu
-}; // namespace eez
+} // namespace eez

--- a/src/eez/modules/psu/datetime.h
+++ b/src/eez/modules/psu/datetime.h
@@ -84,4 +84,4 @@ struct DateTime {
 
 } // namespace datetime
 } // namespace psu
-}; // namespace eez
+} // namespace eez

--- a/src/eez/modules/psu/io_pins.cpp
+++ b/src/eez/modules/psu/io_pins.cpp
@@ -166,12 +166,14 @@ uint32_t calcPwmDutyInt(float duty, uint32_t periodInt) {
 }
 
 void updatePwmDuty(int pin) {
+#if defined EEZ_PLATFORM_STM32
     float duty = g_pwmDuty[pin - DOUT1];
     uint32_t periodInt = g_pwmPeriodInt[pin - DOUT1];
     uint32_t dutyInt = calcPwmDutyInt(duty, periodInt);
-#if defined EEZ_PLATFORM_STM32
     /* Set the Capture Compare Register value */
     TIM3->CCR2 = dutyInt;
+#else
+    (void)pin;
 #endif
 }
 

--- a/src/eez/modules/psu/io_pins.cpp
+++ b/src/eez/modules/psu/io_pins.cpp
@@ -63,7 +63,10 @@ static float g_pwmFrequency[NUM_IO_PINS - DOUT1] = { PWM_DEFAULT_FREQUENCY, PWM_
 static float g_pwmDuty[NUM_IO_PINS - DOUT1] = { PWM_DEFAULT_DUTY, PWM_DEFAULT_DUTY };
 static uint32_t g_pwmPeriodInt[NUM_IO_PINS - DOUT1];
 static bool m_gPwmStarted;
+
+#if defined EEZ_PLATFORM_STM32
 static float g_pwmStartedFrequency;
+#endif
 
 #if defined EEZ_PLATFORM_STM32
 

--- a/src/eez/modules/psu/persist_conf.cpp
+++ b/src/eez/modules/psu/persist_conf.cpp
@@ -202,7 +202,7 @@ void initDefaultDevConf() {
 
     // block 10
     g_defaultDevConf.slotEnabledBits = 0xFF;
-};
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/eez/modules/psu/scpi/syst.cpp
+++ b/src/eez/modules/psu/scpi/syst.cpp
@@ -2004,10 +2004,12 @@ scpi_result_t scpi_cmd_systemMeasureScalarTemperatureThermistorDcQ(scpi_t *conte
     return SCPI_RES_OK;
 }
 
+#if defined(EEZ_PLATFORM_STM32)
 static scpi_choice_def_t systemMeasureVoltageChoice[] = { 
     { "RTC", 1 },
     SCPI_CHOICE_LIST_END 
 };
+#endif
 
 
 scpi_result_t scpi_cmd_systemMeasureScalarVoltageDcQ(scpi_t *context) {

--- a/src/eez/modules/psu/sd_card.cpp
+++ b/src/eez/modules/psu/sd_card.cpp
@@ -91,8 +91,9 @@ static uint32_t g_debounceTimeout;
 ////////////////////////////////////////////////////////////////////////////////
 
 static void stateTransition(Event event);
+#if defined(EEZ_PLATFORM_STM32)
 static void testTimeoutEvent(uint32_t &timeout, Event timeoutEvent);
-
+#endif
 ////////////////////////////////////////////////////////////////////////////////
 
 void init() {
@@ -1074,12 +1075,14 @@ static void clearTimeout(uint32_t &timeout) {
     timeout = 0;
 }
 
+#if defined(EEZ_PLATFORM_STM32)
 static void testTimeoutEvent(uint32_t &timeout, Event timeoutEvent) {
     if (timeout && (int32_t)(millis() - timeout) >= 0) {
         clearTimeout(timeout);
         stateTransition(timeoutEvent);
     }
 }
+#endif
 
 static void stateTransition(Event event) {
     if (g_state == STATE_START) {

--- a/src/eez/mp.cpp
+++ b/src/eez/mp.cpp
@@ -150,7 +150,7 @@ scpi_t g_scpiContext;
 
 void initMessageQueue() {
     eez::psu::scpi::init(g_scpiContext, g_scpiPsuContext, &g_scpiInterface, g_scpiInputBuffer, SCPI_PARSER_INPUT_BUFFER_LENGTH, g_errorQueueData, SCPI_PARSER_ERROR_QUEUE_SIZE + 1);
-    g_mpMessageQueueId = osMessageCreate(osMessageQ(g_mpMessageQueue), NULL);
+    g_mpMessageQueueId = osMessageCreate(osMessageQ(g_mpMessageQueue), 0);
 }
 
 void startThread() {

--- a/src/eez/mp.cpp
+++ b/src/eez/mp.cpp
@@ -339,7 +339,7 @@ bool scpi(const char *commandOrQueryText, const char **resultText, size_t *resul
 
     if (g_lastError != 0) {
         static char g_scpiError[48];
-        snprintf(g_scpiError, 48, "SCPI error %d, \"%s\"", g_lastError, SCPI_ErrorTranslate(g_lastError));
+        snprintf(g_scpiError, 48, "SCPI error %d, \"%s\"", (int)g_lastError, SCPI_ErrorTranslate(g_lastError));
         mp_raise_ValueError(g_scpiError);
     }
 

--- a/src/eez/mqtt.cpp
+++ b/src/eez/mqtt.cpp
@@ -532,7 +532,6 @@ const char *getClientId() {
 #endif
 
 #if defined(EEZ_PLATFORM_SIMULATOR)
-        static const char *CLIENT_ID = "BB3_Simulator";
         sprintf(g_clientId, "BB3_Simulator_%s", getSerialNumber());
 #endif
     }

--- a/src/eez/system.h
+++ b/src/eez/system.h
@@ -34,7 +34,7 @@ extern volatile uint32_t g_tickCount;
 
 #else
 
-#define WATCHDOG_RESET(...) 0
+#define WATCHDOG_RESET(...) (void)0
 
 #endif
 

--- a/src/eez/tasks.cpp
+++ b/src/eez/tasks.cpp
@@ -143,7 +143,7 @@ static uint32_t g_timer1LastTickCount;
 ////////////////////////////////////////////////////////////////////////////////
 
 void initHighPriorityMessageQueue() {
-    g_highPriorityMessageQueueId = osMessageCreate(osMessageQ(g_highPriorityMessageQueue), NULL);
+    g_highPriorityMessageQueueId = osMessageCreate(osMessageQ(g_highPriorityMessageQueue), 0);
 }
 
 void startHighPriorityThread() {
@@ -212,7 +212,7 @@ void sendMessageToPsu(HighPriorityThreadMessage messageType, uint32_t messagePar
 ////////////////////////////////////////////////////////////////////////////////
 
 void initLowPriorityMessageQueue() {
-    g_lowPriorityMessageQueueId = osMessageCreate(osMessageQ(g_lowPriorityMessageQueue), NULL);
+    g_lowPriorityMessageQueueId = osMessageCreate(osMessageQ(g_lowPriorityMessageQueue), 0);
 }
 
 void startLowPriorityThread() {


### PR DESCRIPTION
There were a lot of warnings when building, so I took some time to get rid of most of them.

Most were caused by micropython, so I changed the CMakeLists to turn them into system headers, which do not generate warnings. Most of the other stuff is fairly trivial, and the commits are grouped by type, so it should be pretty simple to review. I think the only changes that might be somewhat questionable is adding the ifdefs around things that are not being used in the simulation - if you don't like that, I can just remove that commit.