### PR TITLE
Add additional readme heading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,9 @@ _For EEZ H24005 firmware visit [psu-firmware](https://github.com/eez-open/psu-fi
 
 ## Build
 
-### Linux
+### Firmware Simulator
+
+#### Linux
 
 ```
 sudo apt-get update
@@ -38,7 +40,7 @@ cmake ../..
 make
 ```
 
-### Emscripten
+#### Emscripten
 
 [Download and install Emscripten](https://emscripten.org/docs/getting_started/downloads.html)
 
@@ -51,7 +53,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../../cmake/Emscripten.cmake -DCMAKE_BUILD_TYPE=Deb
 make
 ```
 
-### Windows
+#### Windows
 
 Install [Visual Studio Community 2017](https://visualstudio.microsoft.com/downloads/) and [CMake](https://cmake.org/install/).
 


### PR DESCRIPTION
mvladic clarified this in Discord, but in an attempt to build the firmware for the stm32 in the BB3 I accidentally built the linux simulator application and was confused why there was no .bin, .hex, or .dfu output.  After understanding the error, it was pretty easy to install cubeIDE and get the correct version built, but an additional heading in the readme might make the distinction clearer for newcomers to the project.  